### PR TITLE
Support all specials chars in json_format function

### DIFF
--- a/Packages/DZ_JSON_MAIN.pkb
+++ b/Packages/DZ_JSON_MAIN.pkb
@@ -2280,9 +2280,7 @@ AS
          RETURN 'null';
 
       ELSE
-         str_output := REGEXP_REPLACE(str_output,'\\'         ,'\\\');
-         str_output := REGEXP_REPLACE(str_output,'/'          ,'\/');    
-         str_output := REGEXP_REPLACE(str_output,'"'          ,'\"');
+         str_output := REGEXP_REPLACE(ASCIISTR(str_output), '\\', '\\u');
          
          str_output := REGEXP_REPLACE(str_output,CHR(8)       ,'\b');
          str_output := REGEXP_REPLACE(str_output,CHR(9)       ,'\t');
@@ -2290,46 +2288,6 @@ AS
          str_output := REGEXP_REPLACE(str_output,CHR(12)      ,'\f');
          str_output := REGEXP_REPLACE(str_output,CHR(13)      ,'');
          str_output := REGEXP_REPLACE(str_output,CHR(21)      ,'\u0015');
-         
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00AE'),'\u00AE');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00B0'),'\u00B0');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00B1'),'\u00B1');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00B2'),'\u00B2');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00B3'),'\u00B3');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00B4'),'\u00B4');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00B5'),'\u00B5');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00B7'),'\u00B7');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00BC'),'\u00BC');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00BD'),'\u00BD');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00C9'),'\u00C9');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00D7'),'\u00D7');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00E0'),'\u00E0');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00E1'),'\u00E1');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00E2'),'\u00E2');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00E3'),'\u00E3');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00E7'),'\u00E7');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00E8'),'\u00E8');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00E9'),'\u00E9');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00EA'),'\u00EA');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00EB'),'\u00EB');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00EC'),'\u00EC');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00ED'),'\u00ED');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00D1'),'\u00D1');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00F3'),'\u00F3');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\00F6'),'\u00F6');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\0161'),'\u0161');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\2013'),'\u2013');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\2014'),'\u2014');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\2015'),'\u2015');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\2018'),'\u2018');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\2019'),'\u2019');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\201B'),'\u201B');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\201C'),'\u201C');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\201D'),'\u201D');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\201F'),'\u201F');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\2022'),'\u2022');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\20AC'),'\u20AC');
-         str_output := REGEXP_REPLACE(str_output,UNISTR('\2122'),'\u2122');
 
          IF p_quote_strings = 'FALSE'
          THEN
@@ -2421,9 +2379,7 @@ AS
          RETURN TO_CLOB('null');
 
       ELSE
-         clb_output := REGEXP_REPLACE(clb_output,'\\'         ,'\\\');
-         clb_output := REGEXP_REPLACE(clb_output,'/'          ,'\/');    
-         clb_output := REGEXP_REPLACE(clb_output,'"'          ,'\"');
+         clb_output := REGEXP_REPLACE(ASCIISTR(clb_output), '\\', '\\u');
          
          clb_output := REGEXP_REPLACE(clb_output,CHR(8)       ,'\b');
          clb_output := REGEXP_REPLACE(clb_output,CHR(9)       ,'\t');
@@ -2431,46 +2387,6 @@ AS
          clb_output := REGEXP_REPLACE(clb_output,CHR(12)      ,'\f');
          clb_output := REGEXP_REPLACE(clb_output,CHR(13)      ,'');
          clb_output := REGEXP_REPLACE(clb_output,CHR(21)      ,'\u0015');
-         
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00AE'),'\u00AE');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00B0'),'\u00B0');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00B1'),'\u00B1');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00B2'),'\u00B2');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00B3'),'\u00B3');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00B4'),'\u00B4');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00B5'),'\u00B5');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00B7'),'\u00B7');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00BC'),'\u00BC');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00BD'),'\u00BD');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00C9'),'\u00C9');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00D7'),'\u00D7');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00E0'),'\u00E0');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00E1'),'\u00E1');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00E2'),'\u00E2');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00E3'),'\u00E3');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00E7'),'\u00E7');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00E8'),'\u00E8');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00E9'),'\u00E9');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00EA'),'\u00EA');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00EB'),'\u00EB');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00EC'),'\u00EC');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00ED'),'\u00ED');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00D1'),'\u00D1');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00F3'),'\u00F3');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\00F6'),'\u00F6');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\0161'),'\u0161');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\2013'),'\u2013');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\2014'),'\u2014');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\2015'),'\u2015');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\2018'),'\u2018');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\2019'),'\u2019');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\201B'),'\u201B');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\201C'),'\u201C');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\201D'),'\u201D');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\201F'),'\u201F');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\2022'),'\u2022');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\20AC'),'\u20AC');
-         clb_output := REGEXP_REPLACE(clb_output,UNISTR('\2122'),'\u2122');
 
          IF p_quote_strings = 'FALSE'
          THEN


### PR DESCRIPTION
Only a handful of specials chars are handled in the json_format functions. As we need to handle french strings with accents in our project, I came out with this little modification to handle all non ascii chars.